### PR TITLE
Moved the socket close call to remove_socket().

### DIFF
--- a/src/lib/bus/listener_cmd.c
+++ b/src/lib/bus/listener_cmd.c
@@ -117,6 +117,7 @@ static void msg_handler(listener *l, listener_msg *pmsg) {
     l->is_idle = false;
 
     listener_msg msg = *pmsg;
+
     switch (msg.type) {
 
     case MSG_ADD_SOCKET:
@@ -216,12 +217,11 @@ static void add_socket(listener *l, connection_info *ci, int notify_fd) {
 }
 
 static void remove_socket(listener *l, int fd, int notify_fd) {
+
     struct bus *b = l->bus;
     BUS_LOG_SNPRINTF(b, 2, LOG_LISTENER, b->udata, 128,
         "removing socket %d", fd);
 
-    /* Don't really close it, just drop info about it in the listener.
-     * The client thread will actually free the structure, close SSL, etc. */
     for (int id = 0; id < l->tracked_fds; id++) {
         struct pollfd removing_pfd = l->fds[id + INCOMING_MSG_PIPE];
         if (removing_pfd.fd == fd) {
@@ -249,6 +249,8 @@ static void remove_socket(listener *l, int fd, int notify_fd) {
             
             l->tracked_fds--;
             if (!is_active) { l->inactive_fds--; }
+
+            syscall_close(fd);
         }
     }
     /* CI will be freed by the client thread. */

--- a/src/lib/kinetic_session.c
+++ b/src/lib/kinetic_session.c
@@ -138,8 +138,8 @@ KineticStatus KineticSession_Disconnect(KineticSession * const session)
     }
     
     // Close the connection
-    KineticSocket_Close(session->socket);
     Bus_ReleaseSocket(session->messageBus, session->socket, NULL);
+
     free(session->si);
     session->si = NULL;
     session->socket = KINETIC_SOCKET_INVALID;


### PR DESCRIPTION
remove_socket() is called based on a msg with a type MSG_REMOVE SOCKET and is passed in msg.u.remove_socket.fd and msg.u.remove_socket.notify_fd which both are set in the Listener_RemoveSocket() function.