### PR TITLE
Develop warningfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ $(SYSTEST_OUT)/run_%: $(SYSTEST_SRC)/%.c $(SYSTEST_OUT)/%_runner.c $(KINETIC_LIB
 	@echo ================================================================================
 	@echo System test: '$<'
 	@echo --------------------------------------------------------------------------------
-	$(CC) -o $@ $< $(word 2,$^) ./test/support/system_test_fixture.c $(UNITY_SRC) $(SYSTEST_CFLAGS) $(LIB_INCS) -I$(UNITY_INC) -I./test/support $(SYSTEST_LDFLAGS) $(KINETIC_LIB)
+	$(CC) -o $@ $< $(word 2,$^) ./test/support/system_test_fixture.c ./test/support/system_test_kv_generate.c $(UNITY_SRC) $(SYSTEST_CFLAGS) $(LIB_INCS) -I$(UNITY_INC) -I./test/support $(SYSTEST_LDFLAGS) $(KINETIC_LIB)
 
 $(SYSTEST_OUT)/%.testpass : $(SYSTEST_OUT)/run_%
 	./scripts/runSystemTest.sh $*

--- a/test/support/system_test_fixture.c
+++ b/test/support/system_test_fixture.c
@@ -24,6 +24,8 @@
 #include "kinetic_admin_client.h"
 
 SystemTestFixture Fixture = {.connected = false};
+static char InitPinData[8];
+static ByteArray InitPin;
 
 static void LoadConfiguration(void)
 {
@@ -158,10 +160,17 @@ int GetSystemTestTlsPort2(void)
     return Fixture.tlsPort2;
 }
 
-void SystemTestSetup(int log_level)
+void SystemTestSetup(int log_level, bool secure_erase)
 {
     const uint8_t *key = (const uint8_t *)SESSION_HMAC_KEY;
     SystemTestSetupWithIdentity(log_level, SESSION_IDENTITY, key, strlen((const char*)key));
+
+    if (secure_erase)
+    {
+        InitPin = ByteArray_Create(InitPinData, 0);
+        KineticStatus status = KineticAdminClient_SecureErase(Fixture.adminSession, InitPin);
+    	TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+    }
 }
 
 void SystemTestSetupWithIdentity(int log_level, int64_t identity,

--- a/test/support/system_test_fixture.h
+++ b/test/support/system_test_fixture.h
@@ -61,7 +61,7 @@ typedef struct _SystemTestFixture {
 
 extern SystemTestFixture Fixture;
 
-void SystemTestSetup(int log_level);
+void SystemTestSetup(int log_level, bool secure_erase);
 void SystemTestSetupWithIdentity(int log_level, int64_t identity,
     const uint8_t *key, size_t key_size);
 void SystemTestShutDown(void);

--- a/test/support/system_test_kv_generate.c
+++ b/test/support/system_test_kv_generate.c
@@ -30,13 +30,13 @@ static const char VALUE_PREFIX[] = "my_value";
 ByteBuffer generate_entry_key_by_index(uint32_t index)
 {
 	char* key = malloc(MAX_SIZE);
-	return ByteBuffer_CreateAndAppendFormattedCString(key, MAX_SIZE, "%s%d",KEY_PREFIX, index);
+	return ByteBuffer_CreateAndAppendFormattedCString(key, MAX_SIZE, "%s%10d",KEY_PREFIX, index);
 }
 
 ByteBuffer generate_entry_value_by_index(uint32_t index)
 {
 	char* value = malloc(MAX_SIZE);
-	return ByteBuffer_CreateAndAppendFormattedCString(value, MAX_SIZE, "%s%d",VALUE_PREFIX, index);
+	return ByteBuffer_CreateAndAppendFormattedCString(value, MAX_SIZE, "%s%10d",VALUE_PREFIX, index);
 }
 
 ByteBuffer get_generated_value_by_key(ByteBuffer* key)

--- a/test/support/system_test_kv_generate.c
+++ b/test/support/system_test_kv_generate.c
@@ -1,0 +1,59 @@
+/*
+* kinetic-c
+* Copyright (C) 2015 Seagate Technology.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+#include "system_test_kv_generate.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+static const int MAX_SIZE = 1024;
+static const char KEY_PREFIX[] = "my_key";
+static const char VALUE_PREFIX[] = "my_value";
+
+ByteBuffer generate_entry_key_by_index(uint32_t index)
+{
+	char* key = malloc(MAX_SIZE);
+	return ByteBuffer_CreateAndAppendFormattedCString(key, MAX_SIZE, "%s%d",KEY_PREFIX, index);
+}
+
+ByteBuffer generate_entry_value_by_index(uint32_t index)
+{
+	char* value = malloc(MAX_SIZE);
+	return ByteBuffer_CreateAndAppendFormattedCString(value, MAX_SIZE, "%s%d",VALUE_PREFIX, index);
+}
+
+ByteBuffer get_generated_value_by_key(ByteBuffer* key)
+{
+	assert(key != NULL);
+	assert(key->array.data != NULL);
+	assert(key->bytesUsed > 0);
+	assert(key->array.len > 0);
+	//assert(strncmp(key->array.data, KEY_PREFIX, strlen(KEY_PREFIX)) == 0);
+
+	ByteBuffer value_buffer;
+	char* value = malloc(MAX_SIZE);
+	sprintf(value, "%s%s", VALUE_PREFIX, key->array.data + strlen(KEY_PREFIX));
+
+	value_buffer.array.data = (uint8_t *)value;
+	value_buffer.array.len = strlen(value);
+	value_buffer.bytesUsed = value_buffer.array.len;
+
+    return value_buffer;
+}

--- a/test/support/system_test_kv_generate.h
+++ b/test/support/system_test_kv_generate.h
@@ -1,0 +1,30 @@
+/*
+* kinetic-c
+* Copyright (C) 2015 Seagate Technology.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+#ifndef _SYSTEM_TEST_KV_GENERATE
+#define _SYSTEM_TEST_KV_GENERATE
+
+#include <stdint.h>
+#include "byte_array.h"
+
+ByteBuffer generate_entry_key_by_index(uint32_t index);
+ByteBuffer generate_entry_value_by_index(uint32_t index);
+ByteBuffer get_generated_value_by_key(ByteBuffer* key);
+
+#endif  //_UNITY_KV_GENERATE

--- a/test/system/test_system_async_io.c
+++ b/test/system/test_system_async_io.c
@@ -35,7 +35,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_async_throughput.c
+++ b/test/system/test_system_async_throughput.c
@@ -27,7 +27,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_delete.c
+++ b/test/system/test_system_delete.c
@@ -30,7 +30,7 @@ static ByteBuffer ValueBuffer;
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 
     KeyBuffer = ByteBuffer_CreateAndAppendCString(KeyData, sizeof(KeyData), "DELETE test key");
     TagBuffer = ByteBuffer_CreateAndAppendCString(TagData, sizeof(TagData), "SomeTagValue");

--- a/test/system/test_system_erase.c
+++ b/test/system/test_system_erase.c
@@ -40,7 +40,7 @@ static bool failing = false;
 
 void setUp(void)
 {
-    SystemTestSetup(0);
+    SystemTestSetup(0, true);
 
     KeyBuffer = ByteBuffer_CreateAndAppendCString(KeyData, sizeof(KeyData), strKey);
     ExpectedKeyBuffer = ByteBuffer_CreateAndAppendCString(ExpectedKeyData, sizeof(ExpectedKeyData), strKey);

--- a/test/system/test_system_flush.c
+++ b/test/system/test_system_flush.c
@@ -22,7 +22,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_get.c
+++ b/test/system/test_system_get.c
@@ -19,60 +19,40 @@
 */
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
+#include "system_test_kv_generate.h"
 
-static uint8_t KeyData[1024];
-static ByteBuffer KeyBuffer;
-static uint8_t ExpectedKeyData[1024];
-static ByteBuffer ExpectedKeyBuffer;
-static uint8_t TagData[1024];
-static ByteBuffer TagBuffer;
-static uint8_t ExpectedTagData[1024];
+static const unsigned int TOTAL_PUT_KEYS = 100;
+static const int DEFAULT_SIZE = 1024;
+
 static ByteBuffer ExpectedTagBuffer;
-static uint8_t VersionData[1024];
-static ByteBuffer VersionBuffer;
-static uint8_t ExpectedVersionData[1024];
 static ByteBuffer ExpectedVersionBuffer;
-static ByteArray TestValue;
-static uint8_t ValueData[KINETIC_OBJ_SIZE];
-static ByteBuffer ValueBuffer;
-static const char strKey[] = "GET system test blob";
-
-static bool initialized = false;
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 
-    if (!initialized) {
-        KeyBuffer = ByteBuffer_CreateAndAppendCString(KeyData, sizeof(KeyData), strKey);
-        ExpectedKeyBuffer = ByteBuffer_CreateAndAppendCString(ExpectedKeyData, sizeof(ExpectedKeyData), strKey);
-        TagBuffer = ByteBuffer_CreateAndAppendCString(TagData, sizeof(TagData), "SomeTagValue");
-        ExpectedTagBuffer = ByteBuffer_CreateAndAppendCString(ExpectedTagData, sizeof(ExpectedTagData), "SomeTagValue");
-        VersionBuffer = ByteBuffer_CreateAndAppendCString(VersionData, sizeof(VersionData), "v1.0");
-        ExpectedVersionBuffer = ByteBuffer_CreateAndAppendCString(ExpectedVersionData, sizeof(ExpectedVersionData), "v1.0");
-        TestValue = ByteArray_CreateWithCString("lorem ipsum... blah blah blah... etc.");
-        ValueBuffer = ByteBuffer_CreateAndAppendArray(ValueData, sizeof(ValueData), TestValue);
+    uint8_t version_data[DEFAULT_SIZE], tag_data[DEFAULT_SIZE];
+    ByteBuffer version_buffer, tag_buffer;
+    version_buffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    ExpectedVersionBuffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    tag_buffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
+    ExpectedTagBuffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
 
-        // Setup to write some test data
+    unsigned int i;
+    for (i=0; i<TOTAL_PUT_KEYS; i++)
+    {
         KineticEntry putEntry = {
-            .key = KeyBuffer,
-            .tag = TagBuffer,
-            .newVersion = VersionBuffer,
-            .algorithm = KINETIC_ALGORITHM_SHA1,
-            .value = ValueBuffer,
-            .force = true,
-            .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
+   	       .key = generate_entry_key_by_index(i),
+   	       .tag = tag_buffer,
+   	       .newVersion = version_buffer,
+           .algorithm = KINETIC_ALGORITHM_SHA1,
+           .value = generate_entry_value_by_index(i),
+           .force = true,
+           .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
         };
 
         KineticStatus status = KineticClient_Put(Fixture.session, &putEntry, NULL);
         TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
-        TEST_ASSERT_EQUAL_ByteBuffer(ExpectedKeyBuffer, putEntry.key);
-        TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, putEntry.tag);
-        TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, putEntry.dbVersion);
-        TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, putEntry.algorithm);
-        TEST_ASSERT_ByteBuffer_NULL(putEntry.newVersion);
-
-        initialized = true;
     }
 }
 
@@ -81,44 +61,81 @@ void tearDown(void)
     SystemTestShutDown();
 }
 
-void test_Get_should_retrieve_object_and_metadata_from_device(void)
+void test_Get_should_retrieve_objects_and_metadata_from_device(void)
 {
-    KineticEntry getEntry = {
-        .key = KeyBuffer,
-        .dbVersion = VersionBuffer,
-        .tag = TagBuffer,
-        .value = ValueBuffer,
-        .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
-    };
+	unsigned int i;
 
-    KineticStatus status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+	for (i=0; i<TOTAL_PUT_KEYS; i++)
+	{
+		ByteBuffer version_buffer, tag_buffer, value_buffer;
+		uint8_t version_data[DEFAULT_SIZE], tag_data[DEFAULT_SIZE], value_data[DEFAULT_SIZE];
+		version_buffer = ByteBuffer_Create(version_data, DEFAULT_SIZE, 0);
+		tag_buffer = ByteBuffer_Create(tag_data, DEFAULT_SIZE, 0);
+		value_buffer = ByteBuffer_Create(value_data, DEFAULT_SIZE, 0);
+		KineticEntry getEntry = {
+	        .key = generate_entry_key_by_index(i),
+			.dbVersion = version_buffer,
+	        .tag = tag_buffer,
+			.value = value_buffer,
+	    };
 
-    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
-    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedKeyBuffer, getEntry.key);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
-    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
-    uint8_t expectedValueData[128];
-    ByteBuffer expectedValue = ByteBuffer_CreateAndAppendArray(expectedValueData, sizeof(expectedValueData), TestValue);
-    TEST_ASSERT_EQUAL_ByteBuffer(expectedValue, getEntry.value);
+	    KineticStatus status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+
+	    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
+	    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
+	    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_key_by_index(i), getEntry.key);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
+	    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
+	    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_value_by_index(i), getEntry.value);
+	}
 }
 
 void test_Get_should_be_able_to_retrieve_just_metadata_from_device(void)
 {
-    KineticEntry getEntry = {
-        .key = KeyBuffer,
-        .dbVersion = VersionBuffer,
-        .tag = TagBuffer,
+	unsigned int i;
+
+	for (i=0; i<TOTAL_PUT_KEYS; i++)
+	{
+		ByteBuffer version_buffer, tag_buffer;
+		uint8_t version_data[DEFAULT_SIZE], tag_data[DEFAULT_SIZE];
+		version_buffer = ByteBuffer_Create(version_data, DEFAULT_SIZE, 0);
+		tag_buffer = ByteBuffer_Create(tag_data, DEFAULT_SIZE, 0);
+		KineticEntry getEntry = {
+	        .key = generate_entry_key_by_index(i),
+			.dbVersion = version_buffer,
+	        .tag = tag_buffer,
+			.metadataOnly = true,
+	    };
+
+		KineticStatus status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+
+	    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
+	    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
+	    TEST_ASSERT_ByteBuffer_NULL(getEntry.value);
+	    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_key_by_index(i), getEntry.key);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
+	    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
+	}
+}
+
+void test_Get_should_returns_null_for_nonexisting_key(void)
+{
+	uint8_t non_existing_key_data[1024];
+	ByteBuffer version_buffer, tag_buffer;
+	uint8_t version_data[DEFAULT_SIZE], tag_data[DEFAULT_SIZE];
+	version_buffer = ByteBuffer_Create(version_data, DEFAULT_SIZE, 0);
+	tag_buffer = ByteBuffer_Create(tag_data, DEFAULT_SIZE, 0);
+	ByteBuffer non_existing_key_buffer = ByteBuffer_CreateAndAppendCString(non_existing_key_data, sizeof(non_existing_key_data), "this is an not existing key");
+	KineticEntry getEntry = {
+        .key = non_existing_key_buffer,
+		.dbVersion = version_buffer,
+        .tag = tag_buffer,
         .metadataOnly = true,
     };
 
     KineticStatus status = KineticClient_Get(Fixture.session, &getEntry, NULL);
 
-    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
-    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedKeyBuffer, getEntry.key);
-    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
-    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
+    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_NOT_FOUND, status);
 }

--- a/test/system/test_system_get_log.c
+++ b/test/system/test_system_get_log.c
@@ -27,7 +27,7 @@ static KineticLogInfo* Info;
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
     Info = NULL;
 }
 

--- a/test/system/test_system_getkeyrange.c
+++ b/test/system/test_system_getkeyrange.c
@@ -20,8 +20,6 @@
 #include "system_test_fixture.h"
 #include "kinetic_client.h"
 
-static bool SuiteInitialized = false;
-
 static bool add_keys(int count)
 {
     static const ssize_t sz = 10;
@@ -47,10 +45,8 @@ static bool add_keys(int count)
 
 void setUp(void)
 {
-    SystemTestSetup(1);
-    if (!SuiteInitialized) {
-        SuiteInitialized = add_keys(3);
-    }
+    SystemTestSetup(1, true);
+    assert(add_keys(3));
 }
 
 void tearDown(void)

--- a/test/system/test_system_getnext_getprevious.c
+++ b/test/system/test_system_getnext_getprevious.c
@@ -22,7 +22,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_idle.c
+++ b/test/system/test_system_idle.c
@@ -28,7 +28,7 @@
 #define IDLE_SECONDS 10
 
 static void child_task(void) {
-    SystemTestSetup(0);
+    SystemTestSetup(0, false);
 
     sleep(IDLE_SECONDS);
 

--- a/test/system/test_system_lock_unlock.c
+++ b/test/system/test_system_lock_unlock.c
@@ -44,7 +44,7 @@ void setUp(void)
     NewPinSet = false;
     Locked = false;
 
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 
     KeyBuffer = ByteBuffer_CreateAndAppendCString(KeyData, sizeof(KeyData), strKey);
     ExpectedKeyBuffer = ByteBuffer_CreateAndAppendCString(ExpectedKeyData, sizeof(ExpectedKeyData), strKey);

--- a/test/system/test_system_noop.c
+++ b/test/system/test_system_noop.c
@@ -22,7 +22,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(3);
+    SystemTestSetup(3, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_put.c
+++ b/test/system/test_system_put.c
@@ -31,7 +31,7 @@ static uint8_t ValueData[KINETIC_OBJ_SIZE];
 static ByteBuffer ValueBuffer;
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
     KeyBuffer = ByteBuffer_CreateAndAppendCString(KeyData, sizeof(KeyData), "PUT test key");
     TagBuffer = ByteBuffer_CreateAndAppendCString(TagData, sizeof(TagData), "SomeTagValue");
     VersionBuffer = ByteBuffer_CreateAndAppendCString(VersionData, sizeof(VersionData), "v1.0");

--- a/test/system/test_system_put_get_delete_mix.c
+++ b/test/system/test_system_put_get_delete_mix.c
@@ -1,0 +1,218 @@
+/*
+* kinetic-c
+* Copyright (C) 2015 Seagate Technology.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*
+*/
+#include "system_test_fixture.h"
+#include "kinetic_client.h"
+#include "system_test_kv_generate.h"
+
+static const unsigned int KV_PAIRS_PER_GROUP = 9;
+static const unsigned int TOTAL_GROUPS = 10;
+static const int DEFAULT_BUFFER_SIZE = 1024;
+
+static ByteBuffer ExpectedTagBuffer;
+static ByteBuffer ExpectedVersionBuffer;
+
+void setUp(void)
+{
+    SystemTestSetup(1, true);
+}
+
+void tearDown(void)
+{
+    SystemTestShutDown();
+}
+
+void test_put_get_delete_one_entry_by_one_entry(void)
+{
+    uint8_t version_data[DEFAULT_BUFFER_SIZE], tag_data[DEFAULT_BUFFER_SIZE], value_data[DEFAULT_BUFFER_SIZE];
+    ByteBuffer version_buffer, tag_buffer, value_buffer;
+    version_buffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    ExpectedVersionBuffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    tag_buffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
+    ExpectedTagBuffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
+    value_buffer = ByteBuffer_Create(value_data, DEFAULT_BUFFER_SIZE, 0);
+
+    unsigned int i;
+    for (i=0; i<KV_PAIRS_PER_GROUP; i++)
+    {
+    	// put object
+        KineticEntry putEntry = {
+   	       .key = generate_entry_key_by_index(i),
+   	       .tag = tag_buffer,
+   	       .newVersion = version_buffer,
+           .algorithm = KINETIC_ALGORITHM_SHA1,
+           .value = generate_entry_value_by_index(i),
+           .force = true,
+           .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
+        };
+
+        KineticStatus status = KineticClient_Put(Fixture.session, &putEntry, NULL);
+        TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+
+        ByteBuffer_Reset(&value_buffer);
+
+        // get object
+		value_buffer = ByteBuffer_Create(value_data, DEFAULT_BUFFER_SIZE, 0);
+		KineticEntry getEntry = {
+	        .key = generate_entry_key_by_index(i),
+			.dbVersion = version_buffer,
+	        .tag = tag_buffer,
+			.value = value_buffer,
+	    };
+
+	    status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+
+	    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
+	    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
+	    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_key_by_index(i), getEntry.key);
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
+	    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
+	    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_value_by_index(i), getEntry.value);
+
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, version_buffer);
+   	    // delete object
+	    KineticEntry deleteEntry = {
+	        .key = generate_entry_key_by_index(i),
+			.dbVersion = version_buffer,
+	    };
+	    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, version_buffer);
+	    status = KineticClient_Delete(Fixture.session, &deleteEntry, NULL);
+	    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+	    TEST_ASSERT_EQUAL(0, deleteEntry.value.bytesUsed);
+
+   	    // get object again
+     	status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+     	TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_NOT_FOUND, status);
+    }
+}
+
+void test_put_get_delete_one_group_by_one_group(void)
+{
+    uint8_t version_data[DEFAULT_BUFFER_SIZE], tag_data[DEFAULT_BUFFER_SIZE], value_data[DEFAULT_BUFFER_SIZE];
+    ByteBuffer version_buffer, tag_buffer, value_buffer;
+    version_buffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    ExpectedVersionBuffer = ByteBuffer_CreateAndAppendCString(version_data, sizeof(version_data), "v1.0");
+    tag_buffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
+    ExpectedTagBuffer = ByteBuffer_CreateAndAppendCString(tag_data, sizeof(tag_data), "SomeTagValue");
+    value_buffer = ByteBuffer_Create(value_data, DEFAULT_BUFFER_SIZE, 0);
+
+    unsigned int i, j;
+    for (i =0; i<TOTAL_GROUPS; i++)
+    {
+    	KineticStatus status;
+
+    	// put a group of entries
+        for (j=0; j<KV_PAIRS_PER_GROUP; j++)
+        {
+            KineticEntry putEntry = {
+       	       .key = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j),
+       	       .tag = tag_buffer,
+       	       .newVersion = version_buffer,
+               .algorithm = KINETIC_ALGORITHM_SHA1,
+               .value = generate_entry_value_by_index(i*KV_PAIRS_PER_GROUP + j),
+               .force = true,
+               .synchronization = KINETIC_SYNCHRONIZATION_WRITETHROUGH,
+            };
+
+            status = KineticClient_Put(Fixture.session, &putEntry, NULL);
+            TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+        }
+
+        // get key_range
+        KineticKeyRange range = {
+            .startKey = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP),
+            .endKey = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + KV_PAIRS_PER_GROUP -1),
+            .startKeyInclusive = true,
+            .endKeyInclusive = true,
+            .maxReturned = KV_PAIRS_PER_GROUP,
+        };
+
+        ByteBuffer keyBuff[KV_PAIRS_PER_GROUP];
+        uint8_t keysData[KV_PAIRS_PER_GROUP][DEFAULT_BUFFER_SIZE];
+        for (j = 0; j < KV_PAIRS_PER_GROUP; j++) {
+            memset(&keysData[j], 0, DEFAULT_BUFFER_SIZE);
+            keyBuff[j] = ByteBuffer_Create(&keysData[j], DEFAULT_BUFFER_SIZE, 0);
+        }
+        ByteBufferArray keys = {.buffers = keyBuff, .count = KV_PAIRS_PER_GROUP, .used = 0};
+
+        status = KineticClient_GetKeyRange(Fixture.session, &range, &keys, NULL);
+        TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+        TEST_ASSERT_EQUAL(KV_PAIRS_PER_GROUP, keys.used);
+        for (j = 0; j < KV_PAIRS_PER_GROUP; j++)
+        {
+        	TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j), keys.buffers[j]);
+        }
+
+        // delete a group of entries
+        for (j=0; j<KV_PAIRS_PER_GROUP; j++)
+        {
+        	ByteBuffer_Reset(&value_buffer);
+
+   	        // get object
+   			value_buffer = ByteBuffer_Create(value_data, DEFAULT_BUFFER_SIZE, 0);
+   			KineticEntry getEntry = {
+   		        .key = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j),
+   				.dbVersion = version_buffer,
+   		        .tag = tag_buffer,
+   				.value = value_buffer,
+   		    };
+
+   		    status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+
+   		    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+   		    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, getEntry.dbVersion);
+   		    TEST_ASSERT_ByteBuffer_NULL(getEntry.newVersion);
+   		    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j), getEntry.key);
+   		    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedTagBuffer, getEntry.tag);
+   		    TEST_ASSERT_EQUAL(KINETIC_ALGORITHM_SHA1, getEntry.algorithm);
+   		    TEST_ASSERT_EQUAL_ByteBuffer(generate_entry_value_by_index(i*KV_PAIRS_PER_GROUP + j), getEntry.value);
+   		    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, version_buffer);
+        }
+
+        // delete a group of entries
+        for (j=0; j<KV_PAIRS_PER_GROUP; j++)
+        {
+        	   	    // delete object
+  		    KineticEntry deleteEntry = {
+   		        .key = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j),
+   				.dbVersion = version_buffer,
+   		    };
+   		    TEST_ASSERT_EQUAL_ByteBuffer(ExpectedVersionBuffer, version_buffer);
+   		    status = KineticClient_Delete(Fixture.session, &deleteEntry, NULL);
+   		    TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_SUCCESS, status);
+   		    TEST_ASSERT_EQUAL(0, deleteEntry.value.bytesUsed);
+
+   	   	    // get object again
+        	ByteBuffer_Reset(&value_buffer);
+
+   	        // get object
+   			value_buffer = ByteBuffer_Create(value_data, DEFAULT_BUFFER_SIZE, 0);
+   			KineticEntry getEntry = {
+   		        .key = generate_entry_key_by_index(i*KV_PAIRS_PER_GROUP + j),
+   				.dbVersion = version_buffer,
+   		        .tag = tag_buffer,
+   				.value = value_buffer,
+   		    };
+   	     	status = KineticClient_Get(Fixture.session, &getEntry, NULL);
+   	     	TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_NOT_FOUND, status);
+        }
+    }
+}
+

--- a/test/system/test_system_receive_thread.c
+++ b/test/system/test_system_receive_thread.c
@@ -22,7 +22,7 @@
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
 }
 
 void tearDown(void)

--- a/test/system/test_system_security.c
+++ b/test/system/test_system_security.c
@@ -36,7 +36,7 @@ void test_Secure_should_set_ACL_and_only_be_able_to_executed_permitted_operation
     /* Set the system an ACL that retains the default HMAC key and all
      * permissions on identity 1, but restricts identity 2 and changes
      * the HMAC key. */
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
     const char *ACL_path = TEST_DIR("system_test.json");
     KineticStatus res = KineticAdminClient_SetACL(Fixture.adminSession,
         ACL_path);
@@ -103,7 +103,7 @@ void test_Secure_should_set_ACL_and_only_be_able_to_executed_permitted_operation
     TEST_ASSERT_EQUAL_KineticStatus(KINETIC_STATUS_NOT_AUTHORIZED, status);
 
     SystemTestShutDown();
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
     
     /* Erase on identity 1 --> Permitted */
     status = KineticAdminClient_SetErasePin(Fixture.adminSession,

--- a/test/system/test_system_set_cluster_version.c
+++ b/test/system/test_system_set_cluster_version.c
@@ -25,7 +25,7 @@ bool ClusterVersionSet;
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, true);
     ClusterVersionSet = false;
 }
 

--- a/test/system/test_system_set_pin.c
+++ b/test/system/test_system_set_pin.c
@@ -27,7 +27,7 @@ bool ErasePinSet, LockPinSet;
 
 void setUp(void)
 {
-    SystemTestSetup(1);
+    SystemTestSetup(1, false);
     ErasePinSet = false;
     LockPinSet = false;
     strcpy(NewPinData, SESSION_PIN);

--- a/test/unit/test_kinetic_client.c
+++ b/test/unit/test_kinetic_client.c
@@ -59,7 +59,7 @@ void tearDown(void)
 
 void test_KineticClient_Version_should_return_pointer_to_static_version_info(void)
 {
-    KineticVersionInfo *info = KineticClient_Version();
+    KineticVersionInfo *info = (KineticVersionInfo *) KineticClient_Version();
     TEST_ASSERT_EQUAL_STRING(KINETIC_C_VERSION, info->version);
     TEST_ASSERT_EQUAL_STRING(KINETIC_C_PROTOCOL_VERSION, info->protocolVersion);
     TEST_ASSERT_EQUAL_STRING(KINETIC_C_REPO_HASH, info->repoCommitHash);


### PR DESCRIPTION
Fix compile warning 
‘test_KineticClient_Version_should_return_pointer_to_static_version_info’:
test/unit/test_kinetic_client.c:62:32: warning: initialization discards ‘const’ qualifier from pointer target type [enabled by default]