### PR TITLE
Add missed free function

### DIFF
--- a/src/lib/kinetic_device_info.c
+++ b/src/lib/kinetic_device_info.c
@@ -317,6 +317,7 @@ cleanup:
     if (statistics) { free(statistics); }
     if (limits) { free(limits); }
     if (device) { free(device); }
+    if (messages.data) { free(messages.data); }
     return NULL;
 }
 


### PR DESCRIPTION
I think that when creating KineticLogInfo is failed, if message.data has the allocated pointer, it should be free.