### PR TITLE
gcc 4.4.7 compatibility 

### DIFF
--- a/src/lib/bus/bus.c
+++ b/src/lib/bus/bus.c
@@ -91,7 +91,7 @@ bool Bus_Init(bus_config *config, struct bus_result *res) {
     struct threadpool *tp = NULL;
     bool *joined = NULL;
     pthread_t *threads = NULL;
-    struct yacht *fd_set = NULL;
+    struct yacht *fds = NULL;
 
     bus *b = calloc(1, sizeof(*b));
     if (b == NULL) { goto cleanup; }
@@ -145,8 +145,8 @@ bool Bus_Init(bus_config *config, struct bus_result *res) {
         goto cleanup;
     }
 
-    fd_set = Yacht_Init(DEF_FD_SET_SIZE2);
-    if (fd_set == NULL) {
+    fds = Yacht_Init(DEF_FD_SET_SIZE2);
+    if (fds == NULL) {
         goto cleanup;
     }
 
@@ -165,7 +165,7 @@ bool Bus_Init(bus_config *config, struct bus_result *res) {
         }
     }
 
-    b->fd_set = fd_set;
+    b->fd_set = fds;
     res->bus = b;
     BUS_LOG(b, 2, LOG_INITIALIZATION, "initialized", config->bus_udata);
     return true;
@@ -187,7 +187,7 @@ cleanup:
     }
 
     if (threads) { free(threads); }
-    if (fd_set) { Yacht_Free(fd_set, NULL, NULL); }
+    if (fds) { Yacht_Free(fds, NULL, NULL); }
 
     return false;
 }

--- a/src/lib/kinetic_builder.c
+++ b/src/lib/kinetic_builder.c
@@ -462,9 +462,9 @@ KineticStatus KineticBuilder_BuildUpdateFirmware(KineticOperation* const op, con
         goto cleanup;
     }
 
-    size_t read = fread(op->value.data, 1, len, fp);
-    if ((long)read != len) {
-        LOGF0("ERROR: Expected to read %ld bytes from FW file, but read %zu", len, read);
+    size_t read_size = fread(op->value.data, 1, len, fp);
+    if ((long)read_size != len) {
+        LOGF0("ERROR: Expected to read %ld bytes from FW file, but read %zu", len, read_size);
         status = KINETIC_STATUS_INVALID_FILE;
         goto cleanup;
     }

--- a/src/lib/kinetic_socket.c
+++ b/src/lib/kinetic_socket.c
@@ -135,45 +135,45 @@ int KineticSocket_Connect(const char* host, int port)
     }
 }
 
-void KineticSocket_Close(int socket)
+void KineticSocket_Close(int fd)
 {
-    if (socket == -1) {
+    if (fd == -1) {
         LOG1("Not connected so no cleanup needed");
     }
     else {
-        LOGF0("Closing socket with fd=%d", socket);
-        if (close(socket) == 0) {
+        LOGF0("Closing socket with fd=%d", fd);
+        if (close(fd) == 0) {
             LOG2("Socket closed successfully");
         }
         else {
             LOGF0("Error closing socket file descriptor!"
                  " (fd=%d, errno=%d, desc='%s')",
-                 socket, errno, strerror(errno));
+                 fd, errno, strerror(errno));
         }
     }
 }
 
-void KineticSocket_EnableTCPNoDelay(int socket)
+void KineticSocket_EnableTCPNoDelay(int fd)
 {
     int on = 1;
-    setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
 }
 
-void KineticSocket_BeginPacket(int socket)
+void KineticSocket_BeginPacket(int fd)
 {
 #if !defined(__APPLE__) /* TCP_CORK is NOT available on OSX */
     int on = 1;
-    setsockopt(socket, IPPROTO_TCP, TCP_CORK, &on, sizeof(on));
+    setsockopt(fd, IPPROTO_TCP, TCP_CORK, &on, sizeof(on));
 #else
     (void)socket;
 #endif
 }
 
-void KineticSocket_FinishPacket(int socket)
+void KineticSocket_FinishPacket(int fd)
 {
 #if !defined(__APPLE__) /* TCP_CORK is NOT available on OSX */
     int off = 0;
-    setsockopt(socket, IPPROTO_TCP, TCP_CORK, &off, sizeof(off));
+    setsockopt(fd, IPPROTO_TCP, TCP_CORK, &off, sizeof(off));
 #else
     (void)socket;
 #endif


### PR DESCRIPTION
Local variable names shadowed global function names (e.g. read), this would cause compile errors with gcc 4.4.7.